### PR TITLE
Add poisoned? and diseased? aliases

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -9883,6 +9883,8 @@ alias :stamina? :checkstamina
 alias :stunned? :checkstunned
 alias :bleeding? :checkbleeding
 alias :reallybleeding? :checkreallybleeding
+alias :poisoned? :checkpoison
+alias :diseased? :checkdisease
 alias :dead? :checkdead
 alias :hiding? :checkhidden
 alias :hidden? :checkhidden


### PR DESCRIPTION
Feels more "ruby-esque" to use these predicate forms and follows convention for the other "?" predicate named aliases, such as `dead?` for `checkdead` and `bleeding?` for `checkbleeding`, etc.