### PR TITLE
Implement custom script subdirectory

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -2471,8 +2471,8 @@ class Script
       end
       # fixme: look in wizard script directory
       # fixme: allow subdirectories?
-      file_list = Dir.entries(SCRIPT_DIR).delete_if { |fn| (fn == '.') or (fn == '..') }.sort
-      if file_name = (file_list.find { |val| val =~ /^#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ || val =~ /^#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i } || file_list.find { |val| val =~ /^#{Regexp.escape(script_name)}[^.]+\.(?i:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ } || file_list.find { |val| val =~ /^#{Regexp.escape(script_name)}[^.]+\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i })
+	  file_list = Dir.children(SCRIPT_DIR) + Dir.children("#{SCRIPT_DIR}/custom").map{ |s| s.prepend("/custom/") }
+      if file_name = (file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ || val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i } || file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}[^.]+\.(?i:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ } || file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}[^.]+\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i })
          script_name = file_name.sub(/\..{1,3}$/, '')
       end
       file_list = nil

--- a/lich.rbw
+++ b/lich.rbw
@@ -2471,7 +2471,7 @@ class Script
       end
       # fixme: look in wizard script directory
       # fixme: allow subdirectories?
-      file_list = Dir.children("#{SCRIPT_DIR}/custom").map{ |s| s.prepend("/custom/") } + Dir.children(SCRIPT_DIR)
+      file_list = Dir.children(File.join(SCRIPT_DIR, "custom")).map{ |s| s.prepend("/custom/") } + Dir.children(SCRIPT_DIR)
       if file_name = (file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ || val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i } || file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}[^.]+\.(?i:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ } || file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}[^.]+\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i })
          script_name = file_name.sub(/\..{1,3}$/, '')
       end
@@ -10222,9 +10222,9 @@ unless File.exists?(SCRIPT_DIR)
       exit
    end
 end
-unless File.exists?("#{SCRIPT_DIR}/custom")
+unless File.exists?(File.join(SCRIPT_DIR, "custom"))
    begin
-      Dir.mkdir("#{SCRIPT_DIR}/custom")
+      Dir.mkdir(File.join(SCRIPT_DIR, "custom"))
    rescue
       Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
       Lich.msgbox(:message => "An error occured while attempting to create directory #{SCRIPT_DIR}\n\n#{$!}", :icon => :error)

--- a/lich.rbw
+++ b/lich.rbw
@@ -37,7 +37,7 @@
 #
 
 # Based on Lich 4.6.56
-LICH_VERSION = '4.13.6f'
+LICH_VERSION = '4.13.7f'
 TESTING = false
 KEEP_SAFE = RUBY_VERSION =~ /^2\.[012]\./
 
@@ -2471,7 +2471,7 @@ class Script
       end
       # fixme: look in wizard script directory
       # fixme: allow subdirectories?
-	  file_list = Dir.children(SCRIPT_DIR) + Dir.children("#{SCRIPT_DIR}/custom").map{ |s| s.prepend("/custom/") }
+      file_list = Dir.children(SCRIPT_DIR) + Dir.children("#{SCRIPT_DIR}/custom").map{ |s| s.prepend("/custom/") }
       if file_name = (file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ || val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i } || file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}[^.]+\.(?i:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ } || file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}[^.]+\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i })
          script_name = file_name.sub(/\..{1,3}$/, '')
       end

--- a/lich.rbw
+++ b/lich.rbw
@@ -10222,6 +10222,15 @@ unless File.exists?(SCRIPT_DIR)
       exit
    end
 end
+unless File.exists?("#{SCRIPT_DIR}/custom")
+   begin
+      Dir.mkdir("#{SCRIPT_DIR}/custom")
+   rescue
+      Lich.log "error: #{$!}\n\t#{$!.backtrace.join("\n\t")}"
+      Lich.msgbox(:message => "An error occured while attempting to create directory #{SCRIPT_DIR}\n\n#{$!}", :icon => :error)
+      exit
+   end
+end
 unless File.exists?(MAP_DIR)
    begin
       Dir.mkdir(MAP_DIR)

--- a/lich.rbw
+++ b/lich.rbw
@@ -2471,7 +2471,7 @@ class Script
       end
       # fixme: look in wizard script directory
       # fixme: allow subdirectories?
-      file_list = Dir.children(SCRIPT_DIR) + Dir.children("#{SCRIPT_DIR}/custom").map{ |s| s.prepend("/custom/") }
+      file_list = Dir.children("#{SCRIPT_DIR}/custom").map{ |s| s.prepend("/custom/") } + Dir.children(SCRIPT_DIR)
       if file_name = (file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ || val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i } || file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}[^.]+\.(?i:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/ } || file_list.find { |val| val =~ /^(?:\/custom\/)?#{Regexp.escape(script_name)}[^.]+\.(?:lic|rb|cmd|wiz)(?:\.gz|\.Z)?$/i })
          script_name = file_name.sub(/\..{1,3}$/, '')
       end


### PR DESCRIPTION
I added in code so that when you try to execute a script it will search both:
`LICH_DIR/scripts` and `LICH_DIR/scripts/custom`

This will allow people to have their own custom scripts in a separate folder so that if a new script is added to github with the same name, their copy doesn't get overwritten.
It also makes it much easier to backup custom scripts for a new install.