### PR TITLE
Custom folder small bug fix

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -2627,12 +2627,19 @@ class Script
       if script_name =~ /\\|\//
          nil
       elsif script_name =~ /\.(?:lic|lich|rb|cmd|wiz)(?:\.gz)?$/i
-         File.exists?("#{SCRIPT_DIR}/#{script_name}")
+         File.exists?("#{SCRIPT_DIR}/#{script_name}") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}")
       else
-         File.exists?("#{SCRIPT_DIR}/#{script_name}.lic") || File.exists?("#{SCRIPT_DIR}/#{script_name}.lich") || File.exists?("#{SCRIPT_DIR}/#{script_name}.rb") || File.exists?("#{SCRIPT_DIR}/#{script_name}.cmd") || File.exists?("#{SCRIPT_DIR}/#{script_name}.wiz") || File.exists?("#{SCRIPT_DIR}/#{script_name}.lic.gz") || File.exists?("#{SCRIPT_DIR}/#{script_name}.rb.gz") || File.exists?("#{SCRIPT_DIR}/#{script_name}.cmd.gz") || File.exists?("#{SCRIPT_DIR}/#{script_name}.wiz.gz")
+         File.exists?("#{SCRIPT_DIR}/#{script_name}.lic") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}.lic") ||
+         File.exists?("#{SCRIPT_DIR}/#{script_name}.lich") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}.lich") ||
+         File.exists?("#{SCRIPT_DIR}/#{script_name}.rb") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}.rb") ||
+         File.exists?("#{SCRIPT_DIR}/#{script_name}.cmd") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}.cmd") ||
+         File.exists?("#{SCRIPT_DIR}/#{script_name}.wiz") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}.wiz") ||
+         File.exists?("#{SCRIPT_DIR}/#{script_name}.lic.gz") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}.lic.gz") ||
+         File.exists?("#{SCRIPT_DIR}/#{script_name}.rb.gz") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}.rb.gz") ||
+         File.exists?("#{SCRIPT_DIR}/#{script_name}.cmd.gz") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}.cmd.gz") ||
+         File.exists?("#{SCRIPT_DIR}/#{script_name}.wiz.gz") || File.exists?("#{SCRIPT_DIR}/custom/#{script_name}.wiz.gz")
       end
-   }
-   @@elevated_log = proc { |data|
+   }   @@elevated_log = proc { |data|
       if script = Script.current
          if script.name =~ /\\|\//
             nil


### PR DESCRIPTION
I get this message when hunting-buddy tries to run one of the scripts in the custom folder.
Same when I try to use DRC.wait_for_script_to_complete().

```R>;e verify_script('CC')
--- Lich: exec1 active.
[exec1: Failed to find a script named 'CC']
[exec1: Please report this to <https://github.com/rpherbig/dr-scripts/issues>]
[exec1: or to Discord <https://discord.gg/ffcEAYfK>]
--- Lich: exec1 has exited.```

I didn't use the File.join() method for these because it caused problems for all of the ones with the extensions included.  I just matched the existing code instead.