### PR TITLE
Custom script already running is not detected

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -37,7 +37,7 @@
 #
 
 # Based on Lich 4.6.56
-LICH_VERSION = '4.13.7f'
+LICH_VERSION = '4.13.8f'
 TESTING = false
 KEEP_SAFE = RUBY_VERSION =~ /^2\.[012]\./
 

--- a/lich.rbw
+++ b/lich.rbw
@@ -2477,10 +2477,10 @@ class Script
       end
       file_list = nil
       if file_name.nil?
-         respond "--- Lich: could not find script '#{script_name}' in directory #{SCRIPT_DIR}"
+         respond "--- Lich: could not find script '#{script_name}' in directory #{SCRIPT_DIR} or #{SCRIPT_DIR}/custom"
          next nil
       end
-      if (options[:force] != true) and (Script.running + Script.hidden).find { |s| s.name =~ /^#{Regexp.escape(script_name)}$/i }
+      if (options[:force] != true) and (Script.running + Script.hidden).find { |s| s.name =~ /^#{Regexp.escape(script_name.sub('/custom/', ''))}$/i }
          respond "--- Lich: #{script_name} is already running (use #{$clean_lich_char}force [scriptname] if desired)."
          next nil
       end


### PR DESCRIPTION
The check to see if a script is already running when you try to run a script isn't detecting scripts from the custom folder.  This fixes that issue.

The problem is that it's comparing the `script_name` for the script that the user wants to run against the names from `Script.running + Script.hidden` and the `script_name` includes `/custom/` at the front for any scripts in the custom folder.

I put in a sub to remove `/custom/ from the `script_name` when it compares the new script to already running scripts.

I also added to the message that gets displayed when a script is not found.  Previously it only showed that it was not found in the `./scripts` directory.  I added `./scripts/custom` to that message to reflect that we're searching both places.