### PR TITLE
[4.13.9f] add match strings to retry swimming movements

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -37,7 +37,7 @@
 #
 
 # Based on Lich 4.6.56
-LICH_VERSION = '4.13.8f'
+LICH_VERSION = '4.13.9f'
 TESTING = false
 KEEP_SAFE = RUBY_VERSION =~ /^2\.[012]\./
 

--- a/lich.rbw
+++ b/lich.rbw
@@ -5020,7 +5020,7 @@ def move(dir='none', giveup_seconds=30, giveup_lines=30)
          put_dir.call
       elsif line =~ /^You flick your hand (?:up|down)wards and focus your aura on your disk, but your disk only wobbles briefly\.$/
          put_dir.call
-      elsif line =~ /^You dive into the fast-moving river, but the current catches you and whips you back to shore, wet and battered\.$|^Running through the swampy terrain, you notice a wet patch in the bog/
+      elsif line =~ /^You dive into the fast-moving river, but the current catches you and whips you back to shore, wet and battered\.$|^Running through the swampy terrain, you notice a wet patch in the bog|^You flounder around in the water.$|^You blunder around in the water, barely able|^You struggle against the swift current to swim|^You slap at the water in a sad failure to swim|^You work against the swift current to swim/
          waitrt?
          put_dir.call
       elsif line == "You don't seem to be able to move to do that."
@@ -7326,7 +7326,7 @@ module Games
                         while $_SERVERSTRING_.include?("<pushStream id=\"combat\" /><pushStream id=\"combat\" />")
                           $_SERVERSTRING_ = $_SERVERSTRING_.gsub("<pushStream id=\"combat\" /><pushStream id=\"combat\" />","<pushStream id=\"combat\" />")
                         end
-                        
+
                         if combat_count >0
                           end_combat_tags.each do | tag |
                             # $_SERVERSTRING_ = "<!-- looking for tag: #{tag}" + $_SERVERSTRING_


### PR DESCRIPTION
### Background
* When trying to swim in difficult water (relative to your skill) then you may encounter various failure messages, but you can retry your movement and you might succeed.
* The following messages were not recognized by lich and so it aborted movement after the first failure attempt and sat there until the 30 second timeout was up.

```
[bescort]>southeast
Roundtime: 15 sec.
You blunder around in the water, barely able to keep your head above the water as you try to swim against the swift current.

You feel fully rested.

[bescort: move: no recognized response in 30 seconds.  giving up.]
```

### Changes
* Add the following match strings when you struggle to swim so that you'll retry
  * `^You flounder around in the water`
  * `^You blunder around in the water, barely able`
  * `^You struggle against the swift current to swim`
  * `^You slap at the water in a sad failure to swim`
  * `^You work against the swift current to swim`

```
[bescort]>southeast
Roundtime: 15 sec.
You flounder around in the water.

[bescort]>southeast
Roundtime: 15 sec.
You swim southeast, moving against the swift current.
```