### PR TITLE
[4.13.10f] don't hang when reach a dark room

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -5029,6 +5029,9 @@ def move(dir='none', giveup_seconds=30, giveup_lines=30)
             sleep 0.1
          }
          put_dir.call
+      elsif line =~ /^It's pitch dark and you can't see a thing!/
+        echo "You will need a light source to continue your journey"
+        return true
       end
       if XMLData.room_count > room_count
          fill_hands if need_full_hands
@@ -7326,7 +7329,7 @@ module Games
                         while $_SERVERSTRING_.include?("<pushStream id=\"combat\" /><pushStream id=\"combat\" />")
                           $_SERVERSTRING_ = $_SERVERSTRING_.gsub("<pushStream id=\"combat\" /><pushStream id=\"combat\" />","<pushStream id=\"combat\" />")
                         end
-                        
+
                         if combat_count >0
                           end_combat_tags.each do | tag |
                             # $_SERVERSTRING_ = "<!-- looking for tag: #{tag}" + $_SERVERSTRING_

--- a/lich.rbw
+++ b/lich.rbw
@@ -37,7 +37,7 @@
 #
 
 # Based on Lich 4.6.56
-LICH_VERSION = '4.13.8f'
+LICH_VERSION = '4.13.10f'
 TESTING = false
 KEEP_SAFE = RUBY_VERSION =~ /^2\.[012]\./
 


### PR DESCRIPTION
### Dependencies
* https://github.com/dragon-realms/dr-lich/pull/69 -- not a true dependency, just trying to order the PRs so the Lich script version increments with each merge

### Background
* While working on https://github.com/rpherbig/dr-scripts/pull/5613, I'm in an area that is pitch black and requires a light source.
* Lich doesn't detect the message `It's pitch dark and you can't see a thing!` when you enter a dark room and hangs for 30 seconds then aborts.
* These particular rooms I'm working in have creatures in them, so sitting around is not safe.

### Changes
* Handle the phrase `It's pitch dark and you can't see a thing!` and stop travelling; and alert the user they need a light source to continue.

```
[bescort]>go stream bank

It's pitch dark and you can't see a thing!
> 
[bescort: You will need a light source to continue your journey]

--- Lich: bescort has exited.
```