### PR TITLE
[4.13.12f] retreat when engaged to move

### DIFF
--- a/lich.rbw
+++ b/lich.rbw
@@ -4889,7 +4889,7 @@ def move(dir='none', giveup_seconds=30, giveup_lines=30)
       end
       if line.nil?
          sleep 0.1
-        elsif line =~ /^You realize that would be next to impossible while in combat.|^You can't do that while engaged!|^You are engaged to |^You need to retreat out of combat first!|^You try to move, but you're engaged|^While in combat\?  You'll have better luck if you first retreat/
+      elsif line =~ /^You realize that would be next to impossible while in combat.|^You can't do that while engaged!|^You are engaged to |^You need to retreat out of combat first!|^You try to move, but you're engaged|^While in combat\?  You'll have better luck if you first retreat/
          # DragonRealms
          fput 'retreat'
          fput 'retreat'

--- a/lich.rbw
+++ b/lich.rbw
@@ -37,7 +37,7 @@
 #
 
 # Based on Lich 4.6.56
-LICH_VERSION = '4.13.8f'
+LICH_VERSION = '4.13.12f'
 TESTING = false
 KEEP_SAFE = RUBY_VERSION =~ /^2\.[012]\./
 
@@ -4889,7 +4889,7 @@ def move(dir='none', giveup_seconds=30, giveup_lines=30)
       end
       if line.nil?
          sleep 0.1
-      elsif line =~ /^You can't do that while engaged!|^You are engaged to |^You need to retreat out of combat first!|^You try to move, but you're engaged|^While in combat\?  You'll have better luck if you first retreat/
+        elsif line =~ /^You realize that would be next to impossible while in combat.|^You can't do that while engaged!|^You are engaged to |^You need to retreat out of combat first!|^You try to move, but you're engaged|^While in combat\?  You'll have better luck if you first retreat/
          # DragonRealms
          fput 'retreat'
          fput 'retreat'
@@ -7326,7 +7326,7 @@ module Games
                         while $_SERVERSTRING_.include?("<pushStream id=\"combat\" /><pushStream id=\"combat\" />")
                           $_SERVERSTRING_ = $_SERVERSTRING_.gsub("<pushStream id=\"combat\" /><pushStream id=\"combat\" />","<pushStream id=\"combat\" />")
                         end
-                        
+
                         if combat_count >0
                           end_combat_tags.each do | tag |
                             # $_SERVERSTRING_ = "<!-- looking for tag: #{tag}" + $_SERVERSTRING_


### PR DESCRIPTION
### Dependencies
* https://github.com/dragon-realms/dr-lich/pull/71 -- not a true dependency, just trying to order the PRs so the Lich script version increments with each merge

### Background
* Missing match string when you're on a mount (e.g. a flying carpet) and engaged and try to move

```
You assess your combat situation...

You (solidly balanced) are facing a cave troll (1) at melee range.
A cave troll (1: nimbly balanced) is facing you at melee range.
A cave troll (2: nimbly balanced) is behind you at melee range.
A cave troll (3: solidly balanced) is flanking you at melee range.

(You are also defending against a cave troll.)

> go bank
You realize that would be next to impossible while in combat.
```

### Changes
* Add match string `You realize that would be next to impossible while in combat.` to retreat then move

### Test
```
> ,e move 'go bank'

--- Lich: exec1 active.

[exec1]>go bank

You realize that would be next to impossible while in combat.
> 
[exec1]>retreat

You retreat back to pole range.
You retreat from combat.
> 
[exec1]>retreat

But you aren't in combat!
> 
[exec1]>go bank

You signal the rug to fly down a stream bank.
```